### PR TITLE
feat(UI): Improvements on forms UX, app colors, font sizes and spacings

### DIFF
--- a/apps/web/app/(protected)/dashboard/[subdomain]/@modal/(.)employees/new/page.tsx
+++ b/apps/web/app/(protected)/dashboard/[subdomain]/@modal/(.)employees/new/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { UserRoundPlus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { NewEmployeeForm } from "@/components/dashboard/employees/new/create-employee-form";
+import { ResponsiveDialogDrawer } from "@/components/ui/responsive-dialog-drawer";
+
+export default function NewEmployeeModal() {
+	const router = useRouter();
+
+	return (
+		<ResponsiveDialogDrawer
+			description="Adicione um ou mais os funcionários na sua empresa."
+			icon={<UserRoundPlus />}
+			title="Cadastrar funcionários"
+		>
+			<NewEmployeeForm onSuccess={() => router.back()} />
+		</ResponsiveDialogDrawer>
+	);
+}

--- a/apps/web/app/(protected)/dashboard/[subdomain]/@modal/(.)service-orders/new/page.tsx
+++ b/apps/web/app/(protected)/dashboard/[subdomain]/@modal/(.)service-orders/new/page.tsx
@@ -1,0 +1,15 @@
+import { ClipboardPlus } from "lucide-react";
+import { NewServiceOrderForm } from "@/components/dashboard/service-order/new-service-order-form";
+import { ResponsiveDialogDrawer } from "@/components/ui/responsive-dialog-drawer";
+
+export default function NewServiceOrderModal() {
+	return (
+		<ResponsiveDialogDrawer
+			description="Preencha os campos abaixo para criar uma nova ordem de serviço."
+			icon={<ClipboardPlus />}
+			title="Criar nova ordem de serviço"
+		>
+			<NewServiceOrderForm />
+		</ResponsiveDialogDrawer>
+	);
+}

--- a/apps/web/app/(protected)/dashboard/[subdomain]/@modal/default.tsx
+++ b/apps/web/app/(protected)/dashboard/[subdomain]/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+	return null;
+}

--- a/apps/web/app/(protected)/dashboard/[subdomain]/layout.tsx
+++ b/apps/web/app/(protected)/dashboard/[subdomain]/layout.tsx
@@ -9,6 +9,7 @@ import { Header } from "@/components/dashboard/sidebar/header";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ThemedToaster } from "@/components/themed-toaster";
 import { getSession } from "@/lib/auth/utils";
+import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
 	title: "Fixr - Dashboard",
@@ -48,9 +49,16 @@ export default async function RootLayout({
 						<SessionProvider>
 							<Sidebar session={session} />
 							<Header />
-							<main className="w-full px-6 py-6 pt-20 transition-all lg:ml-[calc(286px+0.625rem)] lg:w-[calc(100%-(286px+0.625rem))] lg:px-10 lg:py-8">
-								{children}
-							</main>
+							<div className="lg:py-2">
+								<main
+									className={cn(
+										"h-[calc(100dvh-1rem)] overflow-auto bg-card px-5 py-6 pt-20 transition-all",
+										"lg:ml-[286px] lg:w-[calc(100%-(286px+0.5rem))] lg:rounded-md lg:border lg:border-border lg:px-10 lg:py-8"
+									)}
+								>
+									{children}
+								</main>
+							</div>
 						</SessionProvider>
 						<ThemedToaster />
 					</QueryClientWrapper>

--- a/apps/web/app/(protected)/dashboard/[subdomain]/layout.tsx
+++ b/apps/web/app/(protected)/dashboard/[subdomain]/layout.tsx
@@ -30,7 +30,8 @@ const cal = localFont({
 
 export default async function RootLayout({
 	children,
-}: Readonly<{ children: React.ReactNode }>) {
+	modal,
+}: Readonly<{ children: React.ReactNode; modal: React.ReactNode }>) {
 	const cookieStore = await cookies();
 	const session = getSession(cookieStore);
 
@@ -59,6 +60,7 @@ export default async function RootLayout({
 									{children}
 								</main>
 							</div>
+							{modal}
 						</SessionProvider>
 						<ThemedToaster />
 					</QueryClientWrapper>

--- a/apps/web/app/(protected)/dashboard/[subdomain]/service-orders/[id]/loading.tsx
+++ b/apps/web/app/(protected)/dashboard/[subdomain]/service-orders/[id]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+	return "Loading...";
+}

--- a/apps/web/app/(protected)/dashboard/[subdomain]/service-orders/[id]/page.tsx
+++ b/apps/web/app/(protected)/dashboard/[subdomain]/service-orders/[id]/page.tsx
@@ -26,7 +26,7 @@ export default async function ServiceOrderDetailsPage({
 			<div className="flex flex-col gap-3">
 				<Button
 					asChild
-					className="w-fit -translate-x-2.5"
+					className="-mt-3 w-fit -translate-x-2.5"
 					size="sm"
 					variant="ghost"
 				>

--- a/apps/web/app/api/auth/signout/route.ts
+++ b/apps/web/app/api/auth/signout/route.ts
@@ -6,13 +6,8 @@ export async function GET(request: NextRequest) {
 	const redirectUrl = new URL("/auth/login", request.url);
 	const response = NextResponse.redirect(redirectUrl);
 
-	const domain = redirectUrl.hostname;
-	const isSecure = request.url.startsWith("https");
 	const baseOptions = {
 		path: "/",
-		domain,
-		secure: isSecure,
-		sameSite: "none" as const,
 		maxAge: 0,
 	};
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -25,9 +25,9 @@
 	--primary-900: oklch(27.77% 0.1029 266.63);
 	--primary-950: oklch(22.71% 0.0758 268.14);
 
-	--background: oklch(100% 0 0);
+	--background: oklch(98.48% 0 0);
 	--foreground: oklch(14.45% 0 0);
-	--card: oklch(98.48% 0 0);
+	--card: oklch(100% 0 0);
 	--card-foreground: oklch(14.45% 0 0);
 	--popover: oklch(100% 0 0);
 	--popover-foreground: oklch(14.45% 0 0);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -150,6 +150,9 @@
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-ring: var(--sidebar-ring);
 
+	--text-2xs: 0.8125rem;
+	--text-2xs--line-height: 1.125rem;
+
 	--text-5\.5xl: 3.45rem;
 	--text-5\.5xl--line-height: 1;
 	--text-4\.5xl: 2.6rem;

--- a/apps/web/components/auth/login-form.tsx
+++ b/apps/web/components/auth/login-form.tsx
@@ -105,7 +105,7 @@ export function LoginForm({ errors }: { errors?: { google?: string } }) {
 					<h1 className="font-bold text-2xl tracking-tight">
 						Bem vindo ao Fixr!
 					</h1>
-					<p className="text-balance text-muted-foreground text-sm">
+					<p className="text-balance text-2xs text-muted-foreground">
 						Insira suas credenciais e entre na sua conta
 					</p>
 				</div>
@@ -136,7 +136,7 @@ export function LoginForm({ errors }: { errors?: { google?: string } }) {
 								<div className="flex items-center">
 									<FormLabel>Senha *</FormLabel>
 									<Link
-										className="ml-auto text-sm underline-offset-4 hover:underline"
+										className="ml-auto text-2xs underline-offset-4 hover:underline"
 										href="/auth/forgot-password"
 									>
 										Esqueceu sua senha?
@@ -203,7 +203,7 @@ export function LoginForm({ errors }: { errors?: { google?: string } }) {
 							"Entrar"
 						)}
 					</Button>
-					<div className="relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-border after:border-t">
+					<div className="relative text-center text-2xs after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-border after:border-t">
 						<span className="relative z-10 bg-background px-2 text-muted-foreground">
 							Ou continue com
 						</span>
@@ -237,7 +237,7 @@ export function LoginForm({ errors }: { errors?: { google?: string } }) {
 						</CookieAlert>
 					)}
 				</div>
-				<div className="text-center text-sm opacity-30">
+				<div className="text-center text-2xs opacity-30">
 					Projeto universitário sem fins lucrativos.
 				</div>
 			</form>

--- a/apps/web/components/auth/register-form.tsx
+++ b/apps/web/components/auth/register-form.tsx
@@ -116,7 +116,7 @@ export function RegisterForm({
 			>
 				<div className="flex flex-col items-center gap-2 text-center">
 					<h1 className="font-bold text-2xl tracking-tight">Crie uma conta</h1>
-					<p className="text-balance text-muted-foreground text-sm">
+					<p className="text-balance text-2xs text-muted-foreground">
 						Preencha o formulário abaixo para começar
 					</p>
 				</div>
@@ -238,7 +238,7 @@ export function RegisterForm({
 						"Cadastrar"
 					)}
 				</Button>
-				<div className="text-center text-sm">
+				<div className="text-center text-2xs">
 					Já tem uma conta?{" "}
 					<Link className="underline underline-offset-4" href="/auth/login">
 						Faça login

--- a/apps/web/components/dashboard/account-popover.tsx
+++ b/apps/web/components/dashboard/account-popover.tsx
@@ -42,7 +42,7 @@ export function AccountPopover({
 					/>
 					{showData && (
 						<div className="flex min-w-0 flex-col">
-							<p className="overflow-hidden truncate whitespace-nowrap font-medium text-sm">
+							<p className="overflow-hidden truncate whitespace-nowrap font-medium text-2xs">
 								{displayName}
 							</p>
 							<p className="overflow-hidden truncate whitespace-nowrap text-muted-foreground text-xs">

--- a/apps/web/components/dashboard/employees/data-table.tsx
+++ b/apps/web/components/dashboard/employees/data-table.tsx
@@ -110,7 +110,7 @@ export function DataTable<TData, TValue>({
 					</DashLink>
 				</div>
 			</div>
-			<div className="rounded-md border">
+			<div className="rounded-md border bg-background">
 				<Table>
 					<TableHeader>
 						{table.getHeaderGroups().map((headerGroup) => (

--- a/apps/web/components/dashboard/employees/new/create-employee-form.tsx
+++ b/apps/web/components/dashboard/employees/new/create-employee-form.tsx
@@ -118,7 +118,7 @@ export function NewEmployeeForm({
 	return (
 		<Form {...form}>
 			<form
-				className="max-w-xl space-y-5"
+				className="max-w-3xl space-y-5"
 				onSubmit={form.handleSubmit(onSubmit)}
 			>
 				<FormField

--- a/apps/web/components/dashboard/heading.tsx
+++ b/apps/web/components/dashboard/heading.tsx
@@ -18,7 +18,9 @@ export function Heading({
 				</div>
 			)}
 			<div>
-				<h1 className="font-heading font-semibold text-3xl">{title}</h1>
+				<h1 className="t font-heading font-semibold text-2xl lg:text-3xl">
+					{title}
+				</h1>
 				<p className="text-muted-foreground text-sm">{description}</p>
 			</div>
 		</div>

--- a/apps/web/components/dashboard/service-order/layout/sortable-card.tsx
+++ b/apps/web/components/dashboard/service-order/layout/sortable-card.tsx
@@ -28,9 +28,8 @@ export function SortableCard({ id, children }: SortableCardProps) {
 	return (
 		<div
 			className={cn(
-				"relative cursor-grab touch-none transition-shadow",
-				isDragging && "opacity-50",
-				!isDragging && "hover:shadow-sm"
+				"relative cursor-grab touch-none bg-background transition-shadow",
+				isDragging && "opacity-50"
 			)}
 			data-card-id={id}
 			ref={setNodeRef}
@@ -38,7 +37,7 @@ export function SortableCard({ id, children }: SortableCardProps) {
 			{...attributes}
 			{...listeners}
 		>
-			<div className="pointer-events-none absolute top-3 right-3 flex items-center gap-1 rounded-full border bg-background/90 px-2 py-1 text-muted-foreground text-xs">
+			<div className="pointer-events-none absolute top-3 right-3 flex items-center gap-1 rounded-full border bg-card px-2 py-1 text-muted-foreground text-xs">
 				<GripVertical className="size-3" />
 				Arraste
 			</div>

--- a/apps/web/components/dashboard/service-order/lifecycle/service-order-lifecycle.tsx
+++ b/apps/web/components/dashboard/service-order/lifecycle/service-order-lifecycle.tsx
@@ -182,7 +182,7 @@ export function ServiceOrderLifecycle({
 													<span className="block text-muted-foreground text-xs">
 														{entry.dateTime}
 													</span>
-													<p className="text-foreground text-sm">
+													<p className="text-2xs text-foreground">
 														{entry.comment}
 													</p>
 												</div>

--- a/apps/web/components/dashboard/service-order/lifecycle/service-order-lifecycle.tsx
+++ b/apps/web/components/dashboard/service-order/lifecycle/service-order-lifecycle.tsx
@@ -52,6 +52,7 @@ export function ServiceOrderLifecycle({
 			status: getPhaseStatus(0, activeIndex),
 			statuses: ["registered", "analysis"] as ServiceOrderStatusId[],
 			icon: ClipboardList,
+			fillableIcon: false,
 		},
 		{
 			id: "pending",
@@ -64,6 +65,7 @@ export function ServiceOrderLifecycle({
 				"parts_pending",
 			] as ServiceOrderStatusId[],
 			icon: Clock,
+			fillableIcon: false,
 		},
 		{
 			id: "progress",
@@ -84,8 +86,9 @@ export function ServiceOrderLifecycle({
 				"canceled",
 			] as ServiceOrderStatusId[],
 			icon: Check,
+			fillableIcon: false,
 		},
-	] as const;
+	];
 
 	return (
 		<Timeline
@@ -126,6 +129,7 @@ export function ServiceOrderLifecycle({
 								isCompleted,
 								isActive,
 								Icon: phase.icon,
+								fillableIcon: phase.fillableIcon,
 							})}
 						</TimelineDot>
 

--- a/apps/web/components/dashboard/service-order/lifecycle/service-order-lifecycle.tsx
+++ b/apps/web/components/dashboard/service-order/lifecycle/service-order-lifecycle.tsx
@@ -93,7 +93,7 @@ export function ServiceOrderLifecycle({
 	return (
 		<Timeline
 			activeIndex={activeIndex}
-			className="[--timeline-connector-gap:0.75rem] [--timeline-dot-size:2.5rem]"
+			className="[--timeline-connector-gap:0.675rem] [--timeline-dot-size:2.25rem]"
 		>
 			{phases.map((phase, idx) => {
 				const isCompleted = phase.status === "done";
@@ -147,7 +147,9 @@ export function ServiceOrderLifecycle({
 						<TimelineContent>
 							<TimelineHeader className="gap-0.5">
 								<div className="flex items-center justify-between gap-4">
-									<TimelineTitle>{phase.title}</TimelineTitle>
+									<TimelineTitle className="text-sm">
+										{phase.title}
+									</TimelineTitle>
 									<span
 										className={`inline-flex items-center rounded-full px-2.5 py-0.5 font-medium text-xs ${getStatusBadgeClass(
 											{
@@ -164,7 +166,7 @@ export function ServiceOrderLifecycle({
 										})}
 									</span>
 								</div>
-								<TimelineDescription className="text-muted-foreground">
+								<TimelineDescription className="text-2xs text-muted-foreground">
 									{phase.description}
 								</TimelineDescription>
 							</TimelineHeader>

--- a/apps/web/components/dashboard/service-order/lifecycle/utils/helpers.tsx
+++ b/apps/web/components/dashboard/service-order/lifecycle/utils/helpers.tsx
@@ -1,5 +1,6 @@
 import { Check, X } from "lucide-react";
 import type { ComponentType } from "react";
+import { cn } from "@/lib/utils";
 import type { ServiceOrderStatusId } from "@/lib/utils/service-orders";
 import type { PhaseStatus } from "./constants";
 
@@ -94,11 +95,13 @@ export function getDotIcon({
 	isCompleted,
 	isActive,
 	Icon,
+	fillableIcon = true,
 }: {
 	isCanceled: boolean;
 	isCompleted: boolean;
 	isActive: boolean;
 	Icon: ComponentType<{ className?: string }>;
+	fillableIcon?: boolean;
 }) {
 	if (isCanceled) {
 		return <X className="size-6 text-red-100" />;
@@ -107,7 +110,14 @@ export function getDotIcon({
 		return <Check className="size-6 text-green-100" />;
 	}
 	if (isActive) {
-		return <Icon className="size-5 fill-primary-100 text-primary-100" />;
+		return (
+			<Icon
+				className={cn(
+					"size-5 text-primary-100",
+					fillableIcon && "fill-current"
+				)}
+			/>
+		);
 	}
 	return null;
 }

--- a/apps/web/components/dashboard/service-order/service-order-details-card.tsx
+++ b/apps/web/components/dashboard/service-order/service-order-details-card.tsx
@@ -15,7 +15,7 @@ export function ServiceOrderDetailsCard({
 	children,
 }: ServiceOrderDetailsCardProps) {
 	return (
-		<div className="rounded-lg border bg-card">
+		<div className="rounded-lg border bg-background">
 			<div className="flex gap-3 border-b px-4 py-3">
 				<Icon className="mt-1 size-4 text-muted-foreground" />
 				<div>

--- a/apps/web/components/dashboard/service-order/service-order-details-card.tsx
+++ b/apps/web/components/dashboard/service-order/service-order-details-card.tsx
@@ -19,9 +19,9 @@ export function ServiceOrderDetailsCard({
 			<div className="flex gap-3 border-b px-4 py-3">
 				<Icon className="mt-1 size-4 text-muted-foreground" />
 				<div>
-					<h2 className="font-medium">{title}</h2>
+					<h2 className="font-medium text-2xs">{title}</h2>
 					{description && (
-						<p className="text-muted-foreground text-xs">{description}</p>
+						<p className="text-2xs text-muted-foreground">{description}</p>
 					)}
 				</div>
 			</div>

--- a/apps/web/components/dashboard/service-order/table/cells.tsx
+++ b/apps/web/components/dashboard/service-order/table/cells.tsx
@@ -64,7 +64,7 @@ export function DeviceCell({
 }
 
 export function CategoryCell({ category }: { category: string }) {
-	return <span className="text-sm">{category}</span>;
+	return <span className="text-2xs">{category}</span>;
 }
 
 export function TechnicianCell({ name }: { name: string }) {
@@ -98,7 +98,7 @@ export function IssueCell({
 	const desc = description ?? "Sem descrição registrada.";
 	return (
 		<div className="flex flex-col">
-			<span className="max-w-55 truncate text-sm">{desc}</span>
+			<span className="max-w-55 truncate text-2xs">{desc}</span>
 			{notes && (
 				<span className="max-w-55 truncate text-muted-foreground text-xs">
 					{notes}

--- a/apps/web/components/dashboard/service-order/table/toolbar.tsx
+++ b/apps/web/components/dashboard/service-order/table/toolbar.tsx
@@ -33,13 +33,13 @@ export function TableToolbar({
 				</div>
 			</div>
 			<div className="flex justify-start">
-				<Button asChild className="h-9.5 shrink-0">
+				<Button asChild className="shrink-0">
 					<DashLink
 						href={"/service-orders/new"}
 						prefetch
 						subdomain={params.subdomain}
 					>
-						Nova ordem de serviço <Plus className="size-4" />
+						Nova ordem de serviço <Plus className="size-3.5" />
 					</DashLink>
 				</Button>
 			</div>

--- a/apps/web/components/dashboard/service-order/widgets/service-order-image-grid.tsx
+++ b/apps/web/components/dashboard/service-order/widgets/service-order-image-grid.tsx
@@ -26,7 +26,7 @@ function ServiceOrderImageGrid({
 			<div className="grid grid-cols-2 gap-3">
 				{images.map((image) => (
 					<button
-						className="cursor-pointer overflow-hidden rounded-lg border bg-background transition-colors hover:border-primary/50"
+						className="cursor-pointer overflow-hidden rounded-lg border bg-card transition-colors hover:border-primary/50"
 						key={image.id}
 						onClick={() => setSelected(image)}
 						type="button"

--- a/apps/web/components/dashboard/service-order/widgets/service-order-image-grid.tsx
+++ b/apps/web/components/dashboard/service-order/widgets/service-order-image-grid.tsx
@@ -15,7 +15,7 @@ function ServiceOrderImageGrid({
 
 	if (!images || images.length === 0) {
 		return (
-			<p className="text-muted-foreground text-sm">
+			<p className="text-2xs text-muted-foreground">
 				Nenhuma imagem registrada.
 			</p>
 		);
@@ -61,7 +61,7 @@ function ServiceOrderImageGrid({
 								className="max-h-[70vh] w-full rounded-lg object-contain"
 								src={selected.url}
 							/>
-							<p className="text-center text-muted-foreground text-sm">
+							<p className="text-center text-2xs text-muted-foreground">
 								{selected.description}
 							</p>
 						</>

--- a/apps/web/components/dashboard/service-order/widgets/service-order-key-value.tsx
+++ b/apps/web/components/dashboard/service-order/widgets/service-order-key-value.tsx
@@ -34,7 +34,7 @@ function ServiceOrderKeyValueItem({
 }) {
 	if (stacked) {
 		return (
-			<div className={cn("space-y-1", className)}>
+			<div className={cn("space-y-1 text-2xs", className)}>
 				<dt className="text-muted-foreground">{label}</dt>
 				<dd className={cn("wrap-break-word font-medium", valueClassName)}>
 					{value}
@@ -44,7 +44,12 @@ function ServiceOrderKeyValueItem({
 	}
 
 	return (
-		<div className={cn("flex items-start justify-between gap-4", className)}>
+		<div
+			className={cn(
+				"flex items-start justify-between gap-4 text-2xs",
+				className
+			)}
+		>
 			<dt className="shrink-0 text-muted-foreground">{label}</dt>
 			<dd
 				className={cn(

--- a/apps/web/components/dashboard/service-order/widgets/service-order-parts-list.tsx
+++ b/apps/web/components/dashboard/service-order/widgets/service-order-parts-list.tsx
@@ -4,7 +4,7 @@
 function ServiceOrderPartsList({ parts }: { parts?: string[] }) {
 	if (!parts || parts.length === 0) {
 		return (
-			<p className="text-muted-foreground text-sm">Nenhuma peça registrada.</p>
+			<p className="text-2xs text-muted-foreground">Nenhuma peça registrada.</p>
 		);
 	}
 
@@ -12,7 +12,7 @@ function ServiceOrderPartsList({ parts }: { parts?: string[] }) {
 		<div className="grid gap-2">
 			{parts.map((part) => (
 				<div
-					className="flex items-center justify-between rounded-md border bg-card px-3 py-2 text-sm"
+					className="flex items-center justify-between rounded-md border bg-card px-3 py-2 text-2xs"
 					key={part}
 				>
 					<span className="wrap-break-words font-medium">{part}</span>

--- a/apps/web/components/dashboard/service-order/widgets/service-order-parts-list.tsx
+++ b/apps/web/components/dashboard/service-order/widgets/service-order-parts-list.tsx
@@ -12,7 +12,7 @@ function ServiceOrderPartsList({ parts }: { parts?: string[] }) {
 		<div className="grid gap-2">
 			{parts.map((part) => (
 				<div
-					className="flex items-center justify-between rounded-md border bg-muted/40 px-3 py-2 text-sm"
+					className="flex items-center justify-between rounded-md border bg-card px-3 py-2 text-sm"
 					key={part}
 				>
 					<span className="wrap-break-words font-medium">{part}</span>

--- a/apps/web/components/dashboard/sidebar/header.tsx
+++ b/apps/web/components/dashboard/sidebar/header.tsx
@@ -11,12 +11,12 @@ export function Header() {
 	const params = useParams<{ subdomain: string }>();
 
 	return (
-		<header className="absolute z-97 flex h-16 w-full items-center justify-between border-border/30 border-b bg-background/90 px-4 backdrop-blur-xs lg:hidden">
+		<header className="absolute z-40 flex h-16 w-full items-center justify-between border-border/30 border-b bg-card/90 px-4 backdrop-blur-xs lg:hidden">
 			<DashLink href="/home" subdomain={params.subdomain}>
-				<Logo className="size-8" />
+				<Logo className="size-6 text-secondary-foreground" />
 			</DashLink>
 			<p className="text-sm">{getDashboardRouteName(pathname)}</p>
-			<FloatingToggle className="relative z-101" />
+			<FloatingToggle className="relative z-999" />
 		</header>
 	);
 }

--- a/apps/web/components/dashboard/sidebar/header.tsx
+++ b/apps/web/components/dashboard/sidebar/header.tsx
@@ -15,7 +15,7 @@ export function Header() {
 			<DashLink href="/home" subdomain={params.subdomain}>
 				<Logo className="size-6 text-secondary-foreground" />
 			</DashLink>
-			<p className="text-sm">{getDashboardRouteName(pathname)}</p>
+			<p className="text-2xs">{getDashboardRouteName(pathname)}</p>
 			<FloatingToggle className="relative z-999" />
 		</header>
 	);

--- a/apps/web/components/dashboard/sidebar/sidebar-button.tsx
+++ b/apps/web/components/dashboard/sidebar/sidebar-button.tsx
@@ -37,8 +37,10 @@ export function SidebarButton({
 			<Link href={path} id={id} onClick={() => close()} prefetch>
 				<div
 					className={cn(
-						"relative inline-flex w-full items-center gap-2 rounded-sm py-1.5 pr-2 text-secondary-foreground text-sm",
-						active ? "bg-primary/10 text-primary" : "hover:bg-muted/50"
+						"relative inline-flex w-full items-center gap-2 rounded-sm py-1.5 pr-2 font-medium text-secondary-foreground text-sm",
+						active
+							? "bg-primary/10 text-primary"
+							: "text-muted-foreground hover:bg-muted/50 hover:text-secondary-foreground"
 					)}
 					style={{
 						paddingLeft: nestingLevel
@@ -49,7 +51,7 @@ export function SidebarButton({
 					{active && nestingLevel ? (
 						<div className="absolute left-[calc(1rem-0.5px)] h-1/2 w-px bg-primary" />
 					) : null}
-					<Icon className="size-4" />
+					<Icon className="size-3.5" />
 					{label}
 				</div>
 			</Link>

--- a/apps/web/components/dashboard/sidebar/sidebar-button.tsx
+++ b/apps/web/components/dashboard/sidebar/sidebar-button.tsx
@@ -37,7 +37,7 @@ export function SidebarButton({
 			<Link href={path} id={id} onClick={() => close()} prefetch>
 				<div
 					className={cn(
-						"relative inline-flex w-full items-center gap-2 rounded-sm py-1.5 pr-2 font-medium text-secondary-foreground text-sm",
+						"relative inline-flex w-full items-center gap-2 rounded-sm py-1.5 pr-2 font-medium text-2xs text-secondary-foreground",
 						active
 							? "bg-primary/10 text-primary"
 							: "text-muted-foreground hover:bg-muted/50 hover:text-secondary-foreground"
@@ -63,12 +63,12 @@ export function SidebarButton({
 	return (
 		<Collapsible>
 			<CollapsibleTrigger asChild>
-				<div className="group flex w-full cursor-pointer items-center justify-between rounded-sm px-2 py-1.5 text-secondary-foreground text-sm hover:bg-muted/50">
+				<div className="group flex w-full cursor-pointer items-center justify-between rounded-sm px-2 py-1.5 text-2xs text-secondary-foreground hover:bg-muted/50">
 					<div className="inline-flex items-center gap-2">
-						<Icon className="size-4" />
+						<Icon className="size-3.5" />
 						{label}
 					</div>
-					<icons.ChevronDown className="size-4 text-muted-foreground transition-all group-data-[state=open]:rotate-180" />
+					<icons.ChevronDown className="size-3.5 text-muted-foreground transition-all group-data-[state=open]:rotate-180" />
 				</div>
 			</CollapsibleTrigger>
 			<CollapsibleContent className="relative">

--- a/apps/web/components/dashboard/sidebar/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar/sidebar.tsx
@@ -76,7 +76,7 @@ export function Sidebar({ session }: { session: z.infer<typeof userJWT> }) {
 								variant="square"
 							/>
 							<div>
-								<p className="font-medium text-sm tracking-tight">
+								<p className="font-medium text-2xs tracking-tight">
 									{session.company?.name}
 								</p>
 								<p className="text-muted-foreground text-xs tracking-tight">
@@ -87,11 +87,11 @@ export function Sidebar({ session }: { session: z.infer<typeof userJWT> }) {
 					</div>
 					<div className="w-full px-5">
 						<Button
-							className="h-8.5 w-full justify-between bg-muted/50 px-3 text-[0.8rem] text-muted-foreground hover:bg-muted"
+							className="h-8.5 w-full justify-between bg-muted/50 px-3 text-2xs text-muted-foreground hover:bg-muted"
 							variant={"outline"}
 						>
 							<div className="inline-flex items-center gap-1.5">
-								<Search className={"size-4"} />
+								<Search className={"size-3.5"} />
 								Acesso rápido
 							</div>
 							<div className="inline-flex items-center gap-1.5">

--- a/apps/web/components/dashboard/sidebar/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar/sidebar.tsx
@@ -56,7 +56,7 @@ export function Sidebar({ session }: { session: z.infer<typeof userJWT> }) {
 				className={cn(
 					"fixed z-50 flex h-full w-71.5 select-none flex-col justify-between rounded-md bg-background transition-transform max-md:top-2.5 max-md:left-2.5 max-md:h-[calc(100dvh-1.25rem)]",
 					"lg:translate-x-0", // Always visible on desktop
-					"-translate-x-[calc(100%+0.625rem)] data-[state=open]:translate-x-0 max-md:border max-md:border-border" // Slide in on mobile
+					"-translate-x-[calc(100%+0.625rem)] data-[state=open]:translate-x-0 max-lg:border max-lg:border-border" // Slide in on mobile
 				)}
 				data-state={isOpen ? "open" : "closed"}
 			>

--- a/apps/web/components/dashboard/sidebar/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar/sidebar.tsx
@@ -6,7 +6,7 @@ import { PanelLeft, Search } from "lucide-react";
 import type { z } from "zod";
 import { Avatar } from "@/components/account/profile-avatar";
 import { ModeToggle } from "@/components/mode-toggle";
-import { TextLogo } from "@/components/svg/text-logo";
+import { Logo } from "@/components/svg/logo";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useSidebarStore } from "@/lib/hooks/stores/use-sidebar-store";
@@ -54,14 +54,14 @@ export function Sidebar({ session }: { session: z.infer<typeof userJWT> }) {
 		<>
 			<aside
 				className={cn(
-					"fixed top-2.5 left-2.5 z-50 flex h-[calc(100dvh-1.25rem)] w-71.5 select-none flex-col justify-between rounded-md border border-border bg-background transition-transform",
+					"fixed z-50 flex h-full w-71.5 select-none flex-col justify-between rounded-md bg-background transition-transform max-md:top-2.5 max-md:left-2.5 max-md:h-[calc(100dvh-1.25rem)]",
 					"lg:translate-x-0", // Always visible on desktop
-					"-translate-x-[calc(100%+0.625rem)] data-[state=open]:translate-x-0" // Slide in on mobile
+					"-translate-x-[calc(100%+0.625rem)] data-[state=open]:translate-x-0 max-md:border max-md:border-border" // Slide in on mobile
 				)}
 				data-state={isOpen ? "open" : "closed"}
 			>
-				<div className="flex w-full items-center justify-between px-5">
-					<TextLogo className="size-16 text-primary" />
+				<div className="my-4 flex w-full items-center justify-between px-5">
+					<Logo className="size-6 text-primary" />
 					<Button onClick={close} size={"icon"} variant={"ghost"}>
 						<PanelLeft className="text-muted-foreground" />
 					</Button>
@@ -96,13 +96,13 @@ export function Sidebar({ session }: { session: z.infer<typeof userJWT> }) {
 							</div>
 							<div className="inline-flex items-center gap-1.5">
 								<Badge
-									className="grid min-w-5 place-items-center rounded-lg bg-background px-0.5 text-muted-foreground"
+									className="grid min-w-5 place-items-center rounded-sm bg-background px-0.5 text-muted-foreground"
 									variant={"outline"}
 								>
 									⌘
 								</Badge>
 								<Badge
-									className="grid min-w-5 place-items-center rounded-lg bg-background px-0.5 text-muted-foreground"
+									className="grid min-w-5 place-items-center rounded-sm bg-background px-0.5 text-muted-foreground"
 									variant={"outline"}
 								>
 									K
@@ -124,7 +124,7 @@ export function Sidebar({ session }: { session: z.infer<typeof userJWT> }) {
 				>
 					{filteredSections.map((section) => (
 						<div className="space-y-1" key={section.title}>
-							<p className="px-5 font-semibold text-muted-foreground text-xs uppercase tracking-tight">
+							<p className="px-5 font-medium text-muted-foreground text-xs">
 								{section.title}
 							</p>
 							<div className="px-3">
@@ -135,7 +135,7 @@ export function Sidebar({ session }: { session: z.infer<typeof userJWT> }) {
 						</div>
 					))}
 				</div>
-				<div className="flex h-16 w-full shrink-0 items-center justify-between gap-5 rounded-b-md border-border border-t bg-card px-4">
+				<div className="flex h-16 w-full shrink-0 items-center justify-between gap-5 rounded-b-md px-4 py-6">
 					<div className="flex min-w-0 flex-1 items-center">
 						<AccountPopover
 							className="min-w-0 flex-1 overflow-hidden"

--- a/apps/web/components/forgot-password-form.tsx
+++ b/apps/web/components/forgot-password-form.tsx
@@ -93,7 +93,7 @@ export function ForgotPasswordForm({
 					<h1 className="whitespace-nowrap font-bold text-2xl tracking-tight">
 						Esqueceu sua senha?
 					</h1>
-					<p className="text-balance text-muted-foreground text-sm">
+					<p className="text-balance text-2xs text-muted-foreground">
 						Digite seu e-mail abaixo, redefinimos para você!
 					</p>
 				</div>
@@ -166,7 +166,7 @@ export function ForgotPasswordForm({
 						)}
 					</Button>
 				</div>
-				<div className="text-center text-sm">
+				<div className="text-center text-2xs">
 					<Link className="underline underline-offset-4" href="/auth/login">
 						Voltar
 					</Link>

--- a/apps/web/components/reset-password-form.tsx
+++ b/apps/web/components/reset-password-form.tsx
@@ -125,7 +125,7 @@ export function ResetPasswordForm({
 					<h1 className="whitespace-nowrap font-bold text-2xl tracking-tight">
 						Alterar sua senha
 					</h1>
-					<p className="text-balance text-muted-foreground text-sm">
+					<p className="text-balance text-2xs text-muted-foreground">
 						Crie uma nova senha segura e preencha abaixo.
 					</p>
 				</div>
@@ -162,7 +162,7 @@ export function ResetPasswordForm({
 										{...field}
 									/>
 								</FormControl>
-								<FormDescription>
+								<FormDescription className="text-2xs">
 									A confirmação ajuda a garantir que não haja erros de
 									digitação, mantendo sua conta segura.
 								</FormDescription>

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium text-sm outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+	"inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium text-2xs outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 	{
 		variants: {
 			variant: {
@@ -21,12 +21,12 @@ const buttonVariants = cva(
 				link: "text-primary underline-offset-4 hover:underline",
 			},
 			size: {
-				default: "h-9 px-4 py-2 has-[>svg]:px-3",
-				sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-				lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-				icon: "size-9",
-				"icon-sm": "size-8",
-				"icon-lg": "size-10",
+				default: "h-8.5 px-3.5 py-1.5 has-[>svg]:px-2.5",
+				sm: "h-7.5 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2",
+				lg: "h-9.5 rounded-md px-5 has-[>svg]:px-3.5",
+				icon: "size-8.5",
+				"icon-sm": "size-7.5",
+				"icon-lg": "size-9.5",
 			},
 		},
 		defaultVariants: {

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -41,7 +41,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
-			className={cn("text-muted-foreground text-sm", className)}
+			className={cn("text-muted-foreground text-2xs", className)}
 			data-slot="card-description"
 			{...props}
 		/>

--- a/apps/web/components/ui/command.tsx
+++ b/apps/web/components/ui/command.tsx
@@ -73,7 +73,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-2xs outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         {...props}
@@ -104,7 +104,7 @@ function CommandEmpty({
   return (
     <CommandPrimitive.Empty
       data-slot="command-empty"
-      className="py-6 text-center text-sm"
+      className="py-6 text-center text-2xs"
       {...props}
     />
   )
@@ -147,7 +147,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-2xs outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}

--- a/apps/web/components/ui/data-table-pagination.tsx
+++ b/apps/web/components/ui/data-table-pagination.tsx
@@ -37,7 +37,7 @@ export function DataTablePagination<TData>({
     >
       <div className="flex flex-col-reverse items-center gap-4 sm:flex-row sm:gap-6 lg:gap-8">
         <div className="flex items-center space-x-2">
-          <p className="whitespace-nowrap font-medium text-sm">Linhas por página</p>
+          <p className="whitespace-nowrap font-medium text-2xs">Linhas por página</p>
           <Select
             value={`${table.getState().pagination.pageSize}`}
             onValueChange={(value) => {
@@ -56,7 +56,7 @@ export function DataTablePagination<TData>({
             </SelectContent>
           </Select>
         </div>
-        <div className="flex items-center justify-center font-medium text-sm">
+        <div className="flex items-center justify-center font-medium text-2xs">
           Página {table.getState().pagination.pageIndex + 1} de{" "}
           {table.getPageCount()}
         </div>

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -59,7 +59,7 @@ function DialogContent({
 			<DialogOverlay />
 			<DialogPrimitive.Content
 				className={cn(
-					"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:max-w-lg",
+					"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-3xl border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:max-w-lg",
 					className
 				)}
 				data-slot="dialog-content"

--- a/apps/web/components/ui/drawer.tsx
+++ b/apps/web/components/ui/drawer.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import type * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "@/lib/utils";
+
+function Drawer({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+	return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+	return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+	return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+	return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+	return (
+		<DrawerPrimitive.Overlay
+			className={cn(
+				"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in",
+				className
+			)}
+			data-slot="drawer-overlay"
+			{...props}
+		/>
+	);
+}
+
+function DrawerContent({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+	return (
+		<DrawerPortal data-slot="drawer-portal">
+			<DrawerOverlay />
+			<DrawerPrimitive.Content
+				className={cn(
+					"group/drawer-content fixed z-50 flex h-auto flex-col bg-background",
+					"data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+					"data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+					"data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+					"data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+					className
+				)}
+				data-slot="drawer-content"
+				{...props}
+			>
+				<div className="mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+				{children}
+			</DrawerPrimitive.Content>
+		</DrawerPortal>
+	);
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn(
+				"flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+				className
+			)}
+			data-slot="drawer-header"
+			{...props}
+		/>
+	);
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+			data-slot="drawer-footer"
+			{...props}
+		/>
+	);
+}
+
+function DrawerTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+	return (
+		<DrawerPrimitive.Title
+			className={cn("font-semibold text-foreground", className)}
+			data-slot="drawer-title"
+			{...props}
+		/>
+	);
+}
+
+function DrawerDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+	return (
+		<DrawerPrimitive.Description
+			className={cn("text-muted-foreground text-sm", className)}
+			data-slot="drawer-description"
+			{...props}
+		/>
+	);
+}
+
+export {
+	Drawer,
+	DrawerPortal,
+	DrawerOverlay,
+	DrawerTrigger,
+	DrawerClose,
+	DrawerContent,
+	DrawerHeader,
+	DrawerFooter,
+	DrawerTitle,
+	DrawerDescription,
+};

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -71,7 +71,7 @@ function DropdownMenuItem({
 	return (
 		<DropdownMenuPrimitive.Item
 			className={cn(
-				"data-[variant=destructive]:*:[svg]:!text-destructive relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[disabled]:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				"data-[variant=destructive]:*:[svg]:!text-destructive relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-2xs outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[disabled]:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
 				className
 			)}
 			data-inset={inset}
@@ -92,7 +92,7 @@ function DropdownMenuCheckboxItem({
 		<DropdownMenuPrimitive.CheckboxItem
 			checked={checked}
 			className={cn(
-				"relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				"relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-2xs outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 				className
 			)}
 			data-slot="dropdown-menu-checkbox-item"
@@ -127,7 +127,7 @@ function DropdownMenuRadioItem({
 	return (
 		<DropdownMenuPrimitive.RadioItem
 			className={cn(
-				"relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				"relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-2xs outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 				className
 			)}
 			data-slot="dropdown-menu-radio-item"
@@ -153,7 +153,7 @@ function DropdownMenuLabel({
 	return (
 		<DropdownMenuPrimitive.Label
 			className={cn(
-				"px-2 py-1.5 font-medium text-sm data-[inset]:pl-8",
+				"px-2 py-1.5 font-medium text-2xs data-[inset]:pl-8",
 				className
 			)}
 			data-inset={inset}
@@ -209,7 +209,7 @@ function DropdownMenuSubTrigger({
 	return (
 		<DropdownMenuPrimitive.SubTrigger
 			className={cn(
-				"flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[inset]:pl-8 data-[state=open]:text-accent-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				"flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-2xs outline-hidden focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[inset]:pl-8 data-[state=open]:text-accent-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
 				className
 			)}
 			data-inset={inset}

--- a/apps/web/components/ui/form.tsx
+++ b/apps/web/components/ui/form.tsx
@@ -125,7 +125,7 @@ function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
 
 	return (
 		<p
-			className={cn("text-muted-foreground text-sm", className)}
+			className={cn("text-muted-foreground text-2xs", className)}
 			data-slot="form-description"
 			id={formDescriptionId}
 			{...props}
@@ -143,7 +143,7 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
 
 	return (
 		<p
-			className={cn("text-destructive text-sm", className)}
+			className={cn("text-destructive text-2xs", className)}
 			data-slot="form-message"
 			id={formMessageId}
 			{...props}

--- a/apps/web/components/ui/input.tsx
+++ b/apps/web/components/ui/input.tsx
@@ -6,7 +6,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
 	return (
 		<input
 			className={cn(
-				"h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs outline-none transition-[color,box-shadow] selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:font-medium file:text-foreground file:text-sm placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+				"h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 shadow-xs outline-none transition-[color,box-shadow] selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:font-medium file:text-foreground file:text-sm placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 text-sm dark:bg-input/30",
 				"focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
 				"aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
 				className

--- a/apps/web/components/ui/label.tsx
+++ b/apps/web/components/ui/label.tsx
@@ -12,7 +12,7 @@ function Label({
 	return (
 		<LabelPrimitive.Root
 			className={cn(
-				"flex select-none items-center gap-2 font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50",
+				"flex select-none items-center gap-2 font-medium text-2xs leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50",
 				className
 			)}
 			data-slot="label"

--- a/apps/web/components/ui/responsive-dialog-drawer.tsx
+++ b/apps/web/components/ui/responsive-dialog-drawer.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useMediaQuery } from "@/lib/hooks/use-media-query"
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog"
+import {
+	Drawer,
+	DrawerContent,
+	DrawerDescription,
+	DrawerTitle,
+} from "@/components/ui/drawer"
+
+interface ResponsiveDialogDrawerProps {
+	title: string
+	description: string
+	icon?: React.ReactNode
+	children: React.ReactNode
+}
+
+export function ResponsiveDialogDrawer({
+	title,
+	description,
+	icon,
+	children,
+}: ResponsiveDialogDrawerProps) {
+	const router = useRouter()
+	const isDesktop = useMediaQuery("(min-width: 768px)")
+
+	function handleOpenChange(open: boolean) {
+		if (!open) router.back()
+	}
+
+	if (isDesktop) {
+		return (
+			<Dialog onOpenChange={handleOpenChange} open>
+				<DialogContent className="w-full! max-w-3xl! max-h-[calc(100dvh-5rem)] overflow-y-auto">
+					<DialogHeader>
+						<div className="flex items-center gap-4">
+							{icon && (
+								<div className="grid size-12 shrink-0 place-items-center rounded-md bg-primary [&_svg]:size-6 [&_svg]:text-white">
+									{icon}
+								</div>
+							)}
+							<div>
+								<DialogTitle className="font-heading font-semibold text-2xl lg:text-3xl">
+									{title}
+								</DialogTitle>
+								<DialogDescription className="text-muted-foreground text-sm">
+									{description}
+								</DialogDescription>
+							</div>
+						</div>
+					</DialogHeader>
+					{children}
+				</DialogContent>
+			</Dialog>
+		)
+	}
+
+	return (
+		<Drawer onOpenChange={handleOpenChange} open>
+			<DrawerContent>
+				<div className="flex flex-col gap-3 px-4 py-6 text-left">
+					{icon && (
+						<div className="grid size-12 shrink-0 place-items-center rounded-md bg-primary [&_svg]:size-6 [&_svg]:text-white">
+							{icon}
+						</div>
+					)}
+					<div className="space-y-1">
+						<DrawerTitle className="font-heading font-semibold text-2xl">
+							{title}
+						</DrawerTitle>
+						<DrawerDescription className="text-muted-foreground text-sm">
+							{description}
+						</DrawerDescription>
+					</div>
+				</div>
+				<div className="overflow-auto px-4 pb-6">{children}</div>
+			</DrawerContent>
+		</Drawer>
+	)
+}

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -35,7 +35,7 @@ function SelectTrigger({
 	return (
 		<SelectPrimitive.Trigger
 			className={cn(
-				"flex w-fit items-center justify-between gap-2 whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[size=default]:h-9 data-[size=sm]:h-8 data-[placeholder]:text-muted-foreground *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:hover:bg-input/50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				"flex w-fit items-center justify-between gap-2 whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-2xs shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[size=default]:h-9 data-[size=sm]:h-8 data-[placeholder]:text-muted-foreground *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:hover:bg-input/50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
 				className
 			)}
 			data-size={size}
@@ -108,7 +108,7 @@ function SelectItem({
 	return (
 		<SelectPrimitive.Item
 			className={cn(
-				"relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+				"relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-2xs outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
 				className
 			)}
 			data-slot="select-item"

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -120,7 +120,7 @@ function SheetDescription({
 }: React.ComponentProps<typeof SheetPrimitive.Description>) {
 	return (
 		<SheetPrimitive.Description
-			className={cn("text-muted-foreground text-sm", className)}
+			className={cn("text-muted-foreground text-2xs", className)}
 			data-slot="sheet-description"
 			{...props}
 		/>

--- a/apps/web/components/ui/table.tsx
+++ b/apps/web/components/ui/table.tsx
@@ -11,7 +11,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
 			data-slot="table-container"
 		>
 			<table
-				className={cn("w-full caption-bottom text-sm", className)}
+				className={cn("w-full caption-bottom text-2xs", className)}
 				data-slot="table"
 				{...props}
 			/>
@@ -97,7 +97,7 @@ function TableCaption({
 }: React.ComponentProps<"caption">) {
 	return (
 		<caption
-			className={cn("mt-4 text-muted-foreground text-sm", className)}
+			className={cn("mt-4 text-muted-foreground text-2xs", className)}
 			data-slot="table-caption"
 			{...props}
 		/>

--- a/apps/web/components/ui/table.tsx
+++ b/apps/web/components/ui/table.tsx
@@ -69,7 +69,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
 	return (
 		<th
 			className={cn(
-				"h-12 whitespace-nowrap px-4 text-left align-middle font-medium text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+				"h-10 whitespace-nowrap px-4 text-left align-middle font-medium text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
 				className
 			)}
 			data-slot="table-head"
@@ -82,7 +82,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
 	return (
 		<td
 			className={cn(
-				"whitespace-nowrap p-4 align-middle [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5",
+				"whitespace-nowrap px-4 py-3.5 align-middle [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5",
 				className
 			)}
 			data-slot="table-cell"

--- a/apps/web/components/ui/textarea.tsx
+++ b/apps/web/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         return (
             <textarea
                 className={cn(
-                    "w-full min-w-0 min-h-[96px] rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs outline-none transition-[color,box-shadow] selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+                    "w-full min-w-0 min-h-[96px] rounded-md border border-input bg-transparent px-3 py-2 shadow-xs outline-none transition-[color,box-shadow] selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 text-sm dark:bg-input/30",
                     "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
                     "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
                     "resize-y",

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "dotenv": "^17.2.4",
         "dotenv-cli": "^8.0.0",
         "fastify-type-provider-zod": "6.1.0",
+        "vaul": "^1.1.2",
         "vitest": "catalog:",
       },
       "devDependencies": {
@@ -27,7 +28,7 @@
         "tsx": "^4.21.0",
         "typescript": "5.5.4",
         "ultracite": "7.0.12",
-        "web": "workspace:*",
+        "web": "^0.0.2",
       },
     },
     "apps/admin": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "dotenv": "^17.2.4",
     "dotenv-cli": "^8.0.0",
     "fastify-type-provider-zod": "6.1.0",
+    "vaul": "^1.1.2",
     "vitest": "catalog:"
   },
   "devDependencies": {


### PR DESCRIPTION
- Tabela geral de ordens de serviço

|Antes|Depois|
|---|---|
|<img width="1614" height="990" alt="image" src="https://github.com/user-attachments/assets/ea857c39-079f-4964-8b87-6110bae216d6" />|<img width="1616" height="985" alt="image" src="https://github.com/user-attachments/assets/646db2ca-cb5d-42c9-9011-34a11903d20a" />| 
|<img width="1614" height="987" alt="image" src="https://github.com/user-attachments/assets/2a2778fa-b682-4e80-a727-5fae0e7104ac" />|<img width="1612" height="987" alt="image" src="https://github.com/user-attachments/assets/90110db9-9e41-44d4-8b4a-0eb19cebca89" />| 

- Visualização de detalhes da OS

|Antes|Depois|
|---|---|
|<img width="1614" height="986" alt="image" src="https://github.com/user-attachments/assets/dec88cab-5571-4473-b920-de77d934ea2f" />|<img width="1612" height="989" alt="image" src="https://github.com/user-attachments/assets/9682a654-348f-43f2-b20e-e2b4a265f200" />|
|<img width="1614" height="990" alt="image" src="https://github.com/user-attachments/assets/6ae51dd3-d396-4626-8b83-34458eee7518" />|<img width="1615" height="988" alt="image" src="https://github.com/user-attachments/assets/7dae13ae-1217-47fe-873e-8c95b8a36ea9" />| 

- Formulários agora são rotas interceptadas por modais.
   - Mais detalhes sobre: https://nextjs.org/docs/app/api-reference/file-conventions/intercepting-routes

|Antes|Depois|
|---|---|
|<img width="1613" height="988" alt="image" src="https://github.com/user-attachments/assets/e4611698-efb2-41b6-845b-4502b0d67a94" />|<img width="1610" height="986" alt="image" src="https://github.com/user-attachments/assets/e2d9b3fe-f1f4-4f2a-8e14-64451fc473f5" />|
|<img width="1616" height="988" alt="image" src="https://github.com/user-attachments/assets/886b7af5-551c-4af3-90f7-28d710bb9929" />|<img width="1615" height="989" alt="image" src="https://github.com/user-attachments/assets/9168fd77-6d81-497c-a4b6-e89a29de1bce" />|



